### PR TITLE
Deref implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy = { version = "0.7", default-features = false }
-turborand = "0.3"
+turborand = { version = "0.3", features = ["atomic"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ fn setup_player(mut commands: Commands, mut global_rng: ResMut<GlobalRng>) {
 }
 
 fn do_damage(mut q_player: Query<&mut RngComponent, With<Player>>) {
-    let mut rng = q_player.single_mut();
-    // Must call `.get_mut()` to get the Rng instance before it can be used
-    let rng = rng.get_mut();
+    let rng = q_player.single_mut();
     println!("Player attacked for {} damage!", rng.u32(10..=20));
 }
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ fn setup_player(mut commands: Commands, mut global_rng: ResMut<GlobalRng>) {
         .insert(RngComponent::from_global(&mut global_rng));
 }
 
-fn do_damage(mut q_player: Query<&mut RngComponent, With<Player>>) {
-    let rng = q_player.single_mut();
+fn do_damage(mut q_player: Query<&RngComponent, With<Player>>) {
+    let rng = q_player.single();
     println!("Player attacked for {} damage!", rng.u32(10..=20));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,8 @@
 //!         .insert(RngComponent::from_global(&mut global_rng));
 //! }
 //!
-//! fn do_damage(mut q_player: Query<&mut RngComponent, With<Player>>) {
-//!     let rng = q_player.single_mut();
+//! fn do_damage(mut q_player: Query<&RngComponent, With<Player>>) {
+//!     let rng = q_player.single();
 //!     println!("Player attacked for {} damage!", rng.u32(10..=20));
 //! }
 //!
@@ -118,7 +118,7 @@
 #![warn(missing_docs, rust_2018_idioms)]
 
 use bevy::prelude::*;
-use turborand::{CellState, Rng, rng};
+use turborand::{AtomicState, Rng, atomic_rng};
 
 /// Module for dealing directly with [`turborand`] and its features.
 ///
@@ -164,7 +164,7 @@ pub mod rng {
 /// created automatically with [`RngPlugin`], or can be created
 /// and added manually.
 #[derive(Debug, Deref, DerefMut)]
-pub struct GlobalRng(Rng<CellState>);
+pub struct GlobalRng(Rng<AtomicState>);
 
 unsafe impl Sync for GlobalRng {}
 
@@ -184,20 +184,20 @@ impl GlobalRng {
     #[inline]
     #[must_use]
     pub fn with_seed(seed: u64) -> Self {
-        Self(rng!(seed))
+        Self(atomic_rng!(seed))
     }
 
     /// Create a new [`GlobalRng`] instance with a randomized seed value.
     #[inline]
     #[must_use]
     pub fn randomized() -> Self {
-        Self(rng!())
+        Self(atomic_rng!())
     }
 
     /// Returns the internal [`Rng<CellState>`] reference.
     #[inline]
     #[must_use]
-    pub fn get_mut(&mut self) -> &mut Rng<CellState> {
+    pub fn get_mut(&mut self) -> &mut Rng<AtomicState> {
         &mut self.0
     }
 }
@@ -213,7 +213,7 @@ impl Default for GlobalRng {
 
 /// A [`Rng`] component that wraps a random number generator.
 #[derive(Debug, Deref, DerefMut, Component)]
-pub struct RngComponent(Rng<CellState>);
+pub struct RngComponent(Rng<AtomicState>);
 
 unsafe impl Sync for RngComponent {}
 
@@ -233,20 +233,20 @@ impl RngComponent {
     #[inline]
     #[must_use]
     pub fn with_seed(seed: u64) -> Self {
-        Self(rng!(seed))
+        Self(atomic_rng!(seed))
     }
 
     /// Create a new [`RngComponent`] instance with a randomized seed value.
     #[inline]
     #[must_use]
     pub fn randomized() -> Self {
-        Self(rng!())
+        Self(atomic_rng!())
     }
 
     /// Creates a new [`RngComponent`] instance by cloning from an [`Rng<CellState>`].
     #[inline]
     #[must_use]
-    pub fn from_rng(rng: &Rng<CellState>) -> Self {
+    pub fn from_rng(rng: &Rng<AtomicState>) -> Self {
         Self(rng.clone())
     }
 
@@ -261,7 +261,7 @@ impl RngComponent {
     /// Returns the internal [`Rng<CellState>`] reference.
     #[inline]
     #[must_use]
-    pub fn get_mut(&mut self) -> &mut Rng<CellState> {
+    pub fn get_mut(&mut self) -> &mut Rng<AtomicState> {
         &mut self.0
     }
 }

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -37,11 +37,11 @@ struct Enemy;
 /// A system for enemies attacking the player, applying randomised damage if they are able to land a hit.
 fn attack_player(
     mut q_player: Query<&mut HitPoints, (With<Player>, Without<Enemy>)>,
-    mut q_enemies: Query<(&Attack, &mut RngComponent), (With<Enemy>, Without<Player>)>,
+    q_enemies: Query<(&Attack, &RngComponent), (With<Enemy>, Without<Player>)>,
 ) {
     let mut player = q_player.single_mut();
 
-    for (attack, rng) in q_enemies.iter_mut() {
+    for (attack, rng) in q_enemies.iter() {
         if rng.chance(attack.hit) {
             player.total = player.total.saturating_sub(rng.u32(attack.min..=attack.max));
         }
@@ -51,9 +51,9 @@ fn attack_player(
 /// A system for seeing if the player will apply an attack on a random enemy or miss if unlucky!
 fn attack_random_enemy(
     mut q_enemies: Query<&mut HitPoints, (With<Enemy>, Without<Player>)>,
-    mut q_player: Query<(&Attack, &mut RngComponent), (With<Player>, Without<Enemy>)>,
+    q_player: Query<(&Attack, &RngComponent), (With<Player>, Without<Enemy>)>,
 ) {
-    let (attack, rng) = q_player.single_mut();
+    let (attack, rng) = q_player.single();
     for mut enemy in q_enemies.iter_mut() {
         if rng.chance(attack.hit) {
             enemy.total = enemy.total.saturating_sub(rng.u32(attack.min..=attack.max));
@@ -64,7 +64,7 @@ fn attack_random_enemy(
 
 /// A system to randomly apply a healing effect on the player.
 fn buff_player(
-    mut q_player: Query<(&mut HitPoints, &mut RngComponent, &Buff), With<Player>>,
+    mut q_player: Query<(&mut HitPoints, &RngComponent, &Buff), With<Player>>,
 ) {
     let (mut player, rng, buff) = q_player.single_mut();
     if rng.chance(buff.chance) {

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -41,9 +41,7 @@ fn attack_player(
 ) {
     let mut player = q_player.single_mut();
 
-    for (attack, mut rng) in q_enemies.iter_mut() {
-        let rng = rng.get_mut();
-
+    for (attack, rng) in q_enemies.iter_mut() {
         if rng.chance(attack.hit) {
             player.total = player.total.saturating_sub(rng.u32(attack.min..=attack.max));
         }
@@ -55,10 +53,7 @@ fn attack_random_enemy(
     mut q_enemies: Query<&mut HitPoints, (With<Enemy>, Without<Player>)>,
     mut q_player: Query<(&Attack, &mut RngComponent), (With<Player>, Without<Enemy>)>,
 ) {
-    let (attack, mut rng) = q_player.single_mut();
-
-    let rng = rng.get_mut();
-
+    let (attack, rng) = q_player.single_mut();
     for mut enemy in q_enemies.iter_mut() {
         if rng.chance(attack.hit) {
             enemy.total = enemy.total.saturating_sub(rng.u32(attack.min..=attack.max));
@@ -71,10 +66,7 @@ fn attack_random_enemy(
 fn buff_player(
     mut q_player: Query<(&mut HitPoints, &mut RngComponent, &Buff), With<Player>>,
 ) {
-    let (mut player, mut rng, buff) = q_player.single_mut();
-
-    let rng = rng.get_mut();
-
+    let (mut player, rng, buff) = q_player.single_mut();
     if rng.chance(buff.chance) {
         player.total = player.total.saturating_add(rng.u32(buff.min..=buff.max)).clamp(0, player.max);
     }


### PR DESCRIPTION
Adding `Deref` and `DerefMut` derive macro attributes on both the resource and component allow direct usage instead of calling `get_mut` every time.

I also added some `must_use` attributes and extra methods