### PR TITLE
feat(Rng): Enable serialize and rand features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,5 @@ jobs:
         run: cargo check -Z features=dev_dep
       - run: cargo test --all-features
       - name: Test wasm
-        run: wasm-pack test --headless --chrome --firefox
+        run: wasm-pack test --headless --chrome --firefox -- --all-features
         if: startsWith(matrix.os, 'ubuntu')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,15 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 bevy = { version = "0.8.0-dev", git = "https://github.com/bevyengine/bevy", rev="5b5013d54035da09eebdd365b513486248f6726e", default-features = false }
+serde = { version = "1.0", features = ["derive"], optional = true }
 turborand = "0.5"
+
+[dev-dependencies]
+serde_json = "1.0"
+
+[features]
+serialize = ["dep:serde", "turborand/serialize"]
+rand = ["turborand/rand"]
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/component.rs
+++ b/src/component.rs
@@ -3,6 +3,7 @@ use crate::*;
 /// A [`Rng`] component that wraps a random number generator,
 /// specifically a [`Rng<CellState>`].
 #[derive(Debug, Component)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct RngComponent(Rng<CellState>);
 
 unsafe impl Sync for RngComponent {}
@@ -231,6 +232,7 @@ impl Default for RngComponent {
     /// Creates a default [`RngComponent`] instance. The instance will
     /// be initialised with a randomised seed, so this is **not**
     /// deterministic.
+    #[inline]
     fn default() -> Self {
         Self::new(None)
     }

--- a/src/global.rs
+++ b/src/global.rs
@@ -4,6 +4,7 @@ use crate::*;
 /// created automatically with [`RngPlugin`], or can be created
 /// and added manually.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct GlobalRng(Rng<CellState>);
 
 unsafe impl Sync for GlobalRng {}
@@ -212,6 +213,7 @@ impl Default for GlobalRng {
     /// Creates a default [`GlobalRng`] instance. The instance will
     /// be initialised with a randomised seed, so this is **not**
     /// deterministic.
+    #[inline]
     fn default() -> Self {
         Self::new(None)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,12 +118,22 @@
 //!
 //! Methods that are susceptible to this are `usize`, `sample`, `sample_multiple`,
 //! `weighted_sample` and `shuffle`.
+//! 
+//! # Features
+//! 
+//! * `rand` - Provides [`RandCompat`], which implements [`RngCore`] and [`SeedableRng`]
+//!   so to allow for compatibility with `rand` ecosystem of crates.
+//! * `serialize` - Enables [`Serialize`] and [`Deserialize`] derives on [`Rng`],
+//!   [`RngComponent`] and [`GlobalRng`].
 #![warn(missing_docs, rust_2018_idioms)]
 
 use bevy::prelude::*;
 use turborand::{rng, CellState, Rng, State};
 
 use std::{fmt::Debug, ops::RangeBounds};
+
+#[cfg(feature = "serialize")]
+use serde::{Deserialize, Serialize};
 
 pub use component::*;
 pub use global::*;
@@ -191,6 +201,7 @@ impl Default for RngPlugin {
     /// Creates a default [`RngPlugin`] instance. The instance will
     /// be initialised with a randomised seed, so this is **not**
     /// deterministic.
+    #[inline]
     fn default() -> Self {
         Self::new(None)
     }

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -211,3 +211,14 @@ fn deterministic_setup() {
 
     assert_eq!(enemy_2.u32(..=10), 7);
 }
+
+#[cfg(feature = "serialize")]
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn load_rng_setup() {
+    let payload = "{\"state\":24691}";
+
+    let mut rng: RngComponent = serde_json::from_str(payload).unwrap();
+
+    assert_eq!(rng.u32(..10), 4);
+}


### PR DESCRIPTION
Enable the serialization and deserialization of `RngComponent` and `GlobalRng` instances, as well as add a feature for `rand` interoperability.