### PR TITLE
feat(DelegatedRng): *_mut sampling methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_turborand"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A plugin to enable ECS optimised random number generation for the Bevy game engine."

--- a/src/component/chacha.rs
+++ b/src/component/chacha.rs
@@ -86,6 +86,17 @@ impl DelegatedRng for ChaChaRngComponent {
     fn get_mut(&mut self) -> &mut Self::Source {
         &mut self.0
     }
+
+    #[inline]
+    fn weighted_sample_mut<'a, T, F>(
+        &'a mut self,
+        list: &'a mut [T],
+        weight_sampler: F,
+    ) -> Option<&'a mut T>
+    where
+        F: Fn(&T) -> f64 {
+        self.0.weighted_sample_mut(list, weight_sampler)
+    }
 }
 
 impl Default for ChaChaRngComponent {

--- a/src/component/rng.rs
+++ b/src/component/rng.rs
@@ -85,6 +85,17 @@ impl DelegatedRng for RngComponent {
     fn get_mut(&mut self) -> &mut Self::Source {
         &mut self.0
     }
+
+    #[inline]
+    fn weighted_sample_mut<'a, T, F>(
+        &'a mut self,
+        list: &'a mut [T],
+        weight_sampler: F,
+    ) -> Option<&'a mut T>
+    where
+        F: Fn(&T) -> f64 {
+        self.0.weighted_sample_mut(list, weight_sampler)
+    }
 }
 
 impl Default for RngComponent {

--- a/src/global/chacha.rs
+++ b/src/global/chacha.rs
@@ -52,6 +52,17 @@ impl DelegatedRng for GlobalChaChaRng {
     fn get_mut(&mut self) -> &mut Self::Source {
         &mut self.0
     }
+
+    #[inline]
+    fn weighted_sample_mut<'a, T, F>(
+        &'a mut self,
+        list: &'a mut [T],
+        weight_sampler: F,
+    ) -> Option<&'a mut T>
+    where
+        F: Fn(&T) -> f64 {
+        self.0.weighted_sample_mut(list, weight_sampler)
+    }
 }
 
 impl Default for GlobalChaChaRng {

--- a/src/global/rng.rs
+++ b/src/global/rng.rs
@@ -52,6 +52,17 @@ impl DelegatedRng for GlobalRng {
     fn get_mut(&mut self) -> &mut Self::Source {
         &mut self.0
     }
+
+    #[inline]
+    fn weighted_sample_mut<'a, T, F>(
+        &'a mut self,
+        list: &'a mut [T],
+        weight_sampler: F,
+    ) -> Option<&'a mut T>
+    where
+        F: Fn(&T) -> f64 {
+        self.0.weighted_sample_mut(list, weight_sampler)
+    }
 }
 
 impl Default for GlobalRng {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -237,10 +237,22 @@ where
         self.get_mut().sample(list)
     }
 
+    /// Delegated [`TurboRand::sample_mut`] method from [`TurboRand`].
+    #[inline]
+    fn sample_mut<'a, T>(&mut self, list: &'a mut [T]) -> Option<&'a mut T> {
+        self.get_mut().sample_mut(list)
+    }
+
     /// Delegated [`TurboRand::sample_multiple`] method from [`TurboRand`].
     #[inline]
     fn sample_multiple<'a, T>(&mut self, list: &'a [T], amount: usize) -> Vec<&'a T> {
         self.get_mut().sample_multiple(list, amount)
+    }
+
+    /// Delegated [`TurboRand::sample_multiple_mut`] method from [`TurboRand`].
+    #[inline]
+    fn sample_multiple_mut<'a, T>(&mut self, list: &'a mut [T], amount: usize) -> Vec<&'a mut T> {
+        self.get_mut().sample_multiple_mut(list, amount)
     }
 
     /// Delegated [`TurboRand::weighted_sample`] method from [`TurboRand`].
@@ -251,4 +263,13 @@ where
     {
         self.get_mut().weighted_sample(list, weight_sampler)
     }
+
+    /// Delegated [`TurboRand::weighted_sample_mut`] method from [`TurboRand`].
+    fn weighted_sample_mut<'a, T, F>(
+        &'a mut self,
+        list: &'a mut [T],
+        weight_sampler: F,
+    ) -> Option<&'a mut T>
+    where
+        F: Fn(&T) -> f64;
 }


### PR DESCRIPTION
Adding delegated *_mut sampling methods, with a workaround for `weighted_sample_mut`.