### PR TITLE
chore(Rng): Add prelude module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,14 @@ mod delegate;
 mod component;
 #[cfg(any(feature = "chacha", feature = "wyrand"))]
 mod global;
+#[cfg(any(feature = "wyrand", feature = "chacha"))]
+mod plugin;
 mod traits;
+
+/// Prelude for `bevy_turborand`, exposing all necessary traits for default usage of the
+/// crate, as well as whatever component/resources are configured to be exposed by whichever
+/// features are enabled.
+pub mod prelude;
 
 /// Module for dealing directly with [`turborand`] and its features.
 ///
@@ -211,86 +218,4 @@ pub mod rng {
     pub use turborand::prelude::*;
 }
 
-/// A [`Plugin`] for initialising a [`GlobalRng`] & [`GlobalChaChaRng`]
-/// (if the feature flags are enabled for either of them) into a Bevy `App`.
-///
-/// # Example
-/// ```
-/// use bevy::prelude::*;
-/// use bevy_turborand::*;
-///
-/// App::new()
-///     .add_plugin(RngPlugin::new().with_rng_seed(12345))
-///     .run();
-///
-/// ```
-#[cfg(any(feature = "wyrand", feature = "chacha"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "wyrand", feature = "chacha"))))]
-pub struct RngPlugin {
-    #[cfg(feature = "wyrand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
-    rng: Option<u64>,
-    #[cfg(feature = "chacha")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
-    chacha: Option<[u8; 40]>,
-}
-
-#[cfg(any(feature = "wyrand", feature = "chacha"))]
-impl RngPlugin {
-    /// Create a new [`RngPlugin`] instance with no seeds provided by default.
-    /// If initialised as is, this will set the RNGs to have randomised seeds.
-    #[inline]
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            #[cfg(feature = "wyrand")]
-            rng: None,
-            #[cfg(feature = "chacha")]
-            chacha: None,
-        }
-    }
-
-    /// Builder function to set a seed value for a [`GlobalRng`].
-    #[cfg(feature = "wyrand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
-    #[inline]
-    #[must_use]
-    pub const fn with_rng_seed(mut self, seed: u64) -> Self {
-        self.rng = Some(seed);
-        self
-    }
-
-    /// Builder function to set a seed value for a [`GlobalChaChaRng`].
-    #[cfg(feature = "chacha")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
-    #[inline]
-    #[must_use]
-    pub const fn with_chacha_seed(mut self, seed: [u8; 40]) -> Self {
-        self.chacha = Some(seed);
-        self
-    }
-}
-
-#[cfg(any(feature = "wyrand", feature = "chacha"))]
-impl Default for RngPlugin {
-    /// Creates a default [`RngPlugin`] instance. The RNG instances will
-    /// be initialised with randomised seeds, so this is **not**
-    /// deterministic.
-    #[inline]
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg(any(feature = "wyrand", feature = "chacha"))]
-impl Plugin for RngPlugin {
-    fn build(&self, app: &mut App) {
-        #[cfg(feature = "wyrand")]
-        app.insert_resource(self.rng.map_or_else(GlobalRng::new, GlobalRng::with_seed));
-        #[cfg(feature = "chacha")]
-        app.insert_resource(
-            self.chacha
-                .map_or_else(GlobalChaChaRng::new, GlobalChaChaRng::with_seed),
-        );
-    }
-}
+pub use plugin::RngPlugin;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,81 @@
+use crate::*;
+
+/// A [`Plugin`] for initialising a [`GlobalRng`] & [`GlobalChaChaRng`]
+/// (if the feature flags are enabled for either of them) into a Bevy `App`.
+///
+/// # Example
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_turborand::*;
+///
+/// App::new()
+///     .add_plugin(RngPlugin::new().with_rng_seed(12345))
+///     .run();
+///
+/// ```
+#[cfg_attr(docsrs, doc(cfg(any(feature = "wyrand", feature = "chacha"))))]
+pub struct RngPlugin {
+    #[cfg(feature = "wyrand")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
+    rng: Option<u64>,
+    #[cfg(feature = "chacha")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
+    chacha: Option<[u8; 40]>,
+}
+
+impl RngPlugin {
+    /// Create a new [`RngPlugin`] instance with no seeds provided by default.
+    /// If initialised as is, this will set the RNGs to have randomised seeds.
+    #[inline]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "wyrand")]
+            rng: None,
+            #[cfg(feature = "chacha")]
+            chacha: None,
+        }
+    }
+
+    /// Builder function to set a seed value for a [`GlobalRng`].
+    #[cfg(feature = "wyrand")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
+    #[inline]
+    #[must_use]
+    pub const fn with_rng_seed(mut self, seed: u64) -> Self {
+        self.rng = Some(seed);
+        self
+    }
+
+    /// Builder function to set a seed value for a [`GlobalChaChaRng`].
+    #[cfg(feature = "chacha")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
+    #[inline]
+    #[must_use]
+    pub const fn with_chacha_seed(mut self, seed: [u8; 40]) -> Self {
+        self.chacha = Some(seed);
+        self
+    }
+}
+
+impl Default for RngPlugin {
+    /// Creates a default [`RngPlugin`] instance. The RNG instances will
+    /// be initialised with randomised seeds, so this is **not**
+    /// deterministic.
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for RngPlugin {
+    fn build(&self, app: &mut App) {
+        #[cfg(feature = "wyrand")]
+        app.insert_resource(self.rng.map_or_else(GlobalRng::new, GlobalRng::with_seed));
+        #[cfg(feature = "chacha")]
+        app.insert_resource(
+            self.chacha
+                .map_or_else(GlobalChaChaRng::new, GlobalChaChaRng::with_seed),
+        );
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,22 @@
+pub use turborand::{ForkableCore, GenCore, SecureCore, SeededCore, TurboCore, TurboRand};
+
+#[cfg(feature = "wyrand")]
+pub use turborand::prelude::Rng;
+
+#[cfg(feature = "chacha")]
+pub use turborand::prelude::ChaChaRng;
+
+#[cfg(feature = "rand")]
+pub use turborand::prelude::RandBorrowed;
+
+#[cfg(feature = "chacha")]
+pub use crate::component::chacha::ChaChaRngComponent;
+#[cfg(feature = "wyrand")]
+pub use crate::component::rng::RngComponent;
+#[cfg(feature = "chacha")]
+pub use crate::global::chacha::GlobalChaChaRng;
+#[cfg(feature = "wyrand")]
+pub use crate::global::rng::GlobalRng;
+#[cfg(any(feature = "wyrand", feature = "chacha"))]
+pub use crate::plugin::RngPlugin;
+pub use crate::traits::DelegatedRng;

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 
 use bevy::prelude::*;
-use bevy_turborand::*;
+use bevy_turborand::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;


### PR DESCRIPTION
Does what it says on the tin. Not changing what is exposed on the root module level just yet, but will leave that to a major release in our to rejig the project structure. In the mean time, a prelude exposes all the necessary structs/traits by default and will eventually replace the root level usage.