### PR TITLE
Better feature derives, upgrade to bevy v0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_turborand"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A plugin to enable ECS optimised random number generation for the Bevy game engine."
@@ -13,17 +13,17 @@ resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
-turborand = { version = "0.10", default-features = false }
+turborand = { version = "0.10", default-features = false, features=["std", "fmt"] }
 
 [dev-dependencies]
 ron = "0.8"
 
 [features]
 default = ["wyrand", "serialize"]
-wyrand = ["turborand/wyrand", "turborand/std", "turborand/fmt"]
-chacha = ["turborand/chacha", "turborand/std", "turborand/fmt"]
+wyrand = ["turborand/wyrand"]
+chacha = ["turborand/chacha"]
 serialize = ["turborand/serialize", "dep:serde"]
 rand = ["turborand/rand"]
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ fn do_damage(mut q_player: Query<&mut RngComponent, With<Player>>) {
 
 fn main() {
     App::new()
-        .add_plugin(RngPlugin::default())
-        .add_startup_system(setup_player)
-        .add_system(do_damage)
+        .add_plugins(RngPlugin::default())
+        .add_systems(Startup, setup_player)
+        .add_systems(Update, do_damage)
         .run();
 }
 ```
@@ -52,6 +52,7 @@ To see an example of this, view the [project's tests](tests/determinism.rs) to s
 
 | `bevy_turborand` | `bevy` |
 |------------------|--------|
+| v0.6             | v0.11  |
 | v0.5             | v0.10  |
 | v0.4             | v0.9   |
 | v0.2, v0.3       | v0.8   |

--- a/src/component/chacha.rs
+++ b/src/component/chacha.rs
@@ -55,13 +55,14 @@ use crate::*;
 ///    }
 /// }
 /// ```
-#[derive(Debug, Clone, Component, PartialEq)]
+#[derive(Debug, Clone, Component, PartialEq, Reflect)]
 #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serialize",
-    derive(Reflect, FromReflect, Serialize, Deserialize)
+    reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)
 )]
-#[reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "serialize"), reflect_value(Debug, PartialEq, Default))]
 pub struct ChaChaRngComponent(#[reflect(default)] ChaChaRng);
 
 unsafe impl Sync for ChaChaRngComponent {}

--- a/src/component/rng.rs
+++ b/src/component/rng.rs
@@ -71,13 +71,14 @@ use crate::*;
 ///    }
 /// }
 /// ```
-#[derive(Debug, Clone, Component, PartialEq)]
+#[derive(Debug, Clone, Component, PartialEq, Reflect)]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serialize",
-    derive(Reflect, FromReflect, Serialize, Deserialize)
+    reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)
 )]
-#[reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "serialize"), reflect_value(Debug, PartialEq, Default))]
 pub struct RngComponent(#[reflect(default)] Rng);
 
 unsafe impl Sync for RngComponent {}

--- a/src/global/chacha.rs
+++ b/src/global/chacha.rs
@@ -3,13 +3,14 @@ use crate::*;
 /// A Global [`ChaChaRng`] instance, meant for use as a Resource. Gets
 /// created automatically with [`RngPlugin`], or can be created
 /// and added manually.
-#[derive(Debug, Clone, Resource, PartialEq)]
+#[derive(Debug, Clone, Resource, PartialEq, Reflect)]
 #[cfg_attr(docsrs, doc(cfg(feature = "chacha")))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serialize",
-    derive(Reflect, FromReflect, Serialize, Deserialize)
+    reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)
 )]
-#[reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "serialize"), reflect_value(Debug, PartialEq, Default))]
 pub struct GlobalChaChaRng(#[reflect(default)] ChaChaRng);
 
 unsafe impl Sync for GlobalChaChaRng {}

--- a/src/global/rng.rs
+++ b/src/global/rng.rs
@@ -3,13 +3,14 @@ use crate::*;
 /// A Global [`Rng`] instance, meant for use as a Resource. Gets
 /// created automatically with [`RngPlugin`], or can be created
 /// and added manually.
-#[derive(Debug, Clone, Resource, PartialEq)]
+#[derive(Debug, Clone, Resource, PartialEq, Reflect)]
 #[cfg_attr(docsrs, doc(cfg(feature = "wyrand")))]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "serialize",
-    derive(Reflect, FromReflect, Serialize, Deserialize)
+    reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)
 )]
-#[reflect_value(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "serialize"), reflect_value(Debug, PartialEq, Default))]
 pub struct GlobalRng(#[reflect(default)] Rng);
 
 unsafe impl Sync for GlobalRng {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,9 @@
 //!
 //! fn main() {
 //!     App::new()
-//!         .add_plugin(RngPlugin::default())
-//!         .add_startup_system(setup_player)
-//!         .add_system(do_damage)
+//!         .add_plugins(RngPlugin::default())
+//!         .add_systems(Startup, setup_player)
+//!         .add_systems(Update, do_damage)
 //!         .run();
 //! }
 //! ```
@@ -128,7 +128,7 @@
 //! because the output of the RNG source for usize on 32-bit platforms
 //! is `u32` and thus is truncating the full output from the generator.
 //! As such, it will not be the same value between 32-bit and 64-bit platforms.
-//! 
+//!
 //! For ensuring stable results between 32-bit and 64-bit platforms, use the [`TurboRand::index`]
 //! method instead. All sampling/shuffing methods use this method internally to ensure
 //! stable results. Do note, [`TurboRand`] optimises cases for 64-bit platforms,
@@ -148,11 +148,13 @@
 #![cfg_attr(docsrs, allow(unused_attributes))]
 
 use bevy::prelude::*;
-#[cfg(any(feature = "chacha", feature = "wyrand"))]
-use turborand::prelude::*;
+#[cfg(feature = "chacha")]
+use turborand::prelude::ChaChaRng;
+#[cfg(feature = "wyrand")]
+use turborand::prelude::Rng;
 pub use turborand::{ForkableCore, GenCore, SecureCore, SeededCore, TurboCore, TurboRand};
 
-#[cfg(feature = "serialize")]
+#[cfg(all(any(feature = "chacha", feature = "wyrand"), feature = "serialize"))]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "chacha")]
@@ -219,5 +221,3 @@ pub mod prelude;
 pub mod rng {
     pub use turborand::prelude::*;
 }
-
-pub use plugin::RngPlugin;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -11,7 +11,7 @@ use crate::*;
 /// use bevy_turborand::prelude::*;
 ///
 /// App::new()
-///     .add_plugin(RngPlugin::new().with_rng_seed(12345))
+///     .add_plugins(RngPlugin::new().with_rng_seed(12345))
 ///     .run();
 ///
 /// ```

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,7 +2,7 @@ use crate::*;
 use std::{fmt::Debug, ops::RangeBounds};
 
 #[cfg(feature = "rand")]
-use crate::RandBorrowed;
+use turborand::prelude::RandBorrowed;
 
 /// A trait for applying to [`Component`]s and Resources that wrap a [`TurboCore`] RNG source.
 ///

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -161,9 +161,10 @@ fn deterministic_play_through() {
 
     // Add the systems to our App. Order the necessary systems in order
     // to ensure deterministic behaviour.
-    app.add_system(attack_player);
-    app.add_system(attack_random_enemy);
-    app.add_system(buff_player.after(attack_player));
+    app.add_systems(
+        Update,
+        ((attack_random_enemy, buff_player).chain(), attack_player),
+    );
 
     // Run the game once!
     app.update();
@@ -197,8 +198,7 @@ fn deterministic_setup() {
 
     app.insert_resource(GlobalRng::with_seed(23456));
 
-    app.add_startup_system(setup_player);
-    app.add_startup_system(setup_enemies.after(setup_player));
+    app.add_systems(Startup, (setup_player, setup_enemies).chain());
 
     app.update();
 
@@ -229,8 +229,7 @@ fn deterministic_secure_setup() {
 
     app.insert_resource(GlobalChaChaRng::with_seed([1; 40]));
 
-    app.add_startup_system(setup_secure_player);
-    app.add_startup_system(setup_secure_enemies.after(setup_secure_player));
+    app.add_systems(Startup, (setup_secure_player, setup_secure_enemies).chain());
 
     app.update();
 


### PR DESCRIPTION
Fixes some feature derives on various structs, updates the bevy version of the crate to support v0.11, with all the tests updated with the latest API changes.