### PR TITLE
Updated to bevy 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 .vscode
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_turborand"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A plugin to enable ECS optimised random number generation for the Bevy game engine."
@@ -13,7 +13,7 @@ resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bevy = { version = "0.12", default-features = false }
+bevy = { version = "0.13", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 turborand = { version = "0.10", default-features = false, features=["std", "fmt"] }
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To see an example of this, view the [project's tests](tests/determinism.rs) to s
 
 | `bevy_turborand` | `bevy` |
 |------------------|--------|
+| v0.8             | v0.13  |
 | v0.7             | v0.12  |
 | v0.6             | v0.11  |
 | v0.5             | v0.10  |


### PR DESCRIPTION
There were no breaking changes.
It was sufficient to bump version and update ReadMe.