### PR TITLE
Bevy 0.14.0-rc.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,12 @@ serialize = ["turborand/serialize", "dep:serde"]
 rand = ["turborand/rand"]
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
+bevy = { version = "0.14.0-rc.4", default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
-turborand = { version = "0.10", default-features = false, features=["std", "fmt"] }
+turborand = { version = "0.10", default-features = false, features = [
+  "std",
+  "fmt",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.instant]
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_turborand"
-version = "0.8.2"
+version = "0.9.0-rc.1"
 edition = "2021"
 authors = ["Gonçalo Rica Pais da Silva <bluefinger@gmail.com>"]
 description = "A plugin to enable ECS optimised random number generation for the Bevy game engine."

--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ To see an example of this, view the [project's tests](tests/determinism.rs) to s
 
 ## Supported Versions
 
-| `bevy_turborand` | `bevy` |
-|------------------|--------|
-| v0.8             | v0.13  |
-| v0.7             | v0.12  |
-| v0.6             | v0.11  |
-| v0.5             | v0.10  |
-| v0.4             | v0.9   |
-| v0.2, v0.3       | v0.8   |
-| v0.1             | v0.7   |
+| `bevy_turborand`   | `bevy`       |
+|--------------------|--------------|
+| v0.9.0-rc.1        | v0.14.0-rc.4 |
+| v0.8               | v0.13        |
+| v0.7               | v0.12        |
+| v0.6               | v0.11        |
+| v0.5               | v0.10        |
+| v0.4               | v0.9         |
+| v0.2, v0.3         | v0.8         |
+| v0.1               | v0.7         |
 
 MSRV for `bevy_turborand` is the same as in `bevy`, so always the latest Rust compiler version.
 

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -283,7 +283,7 @@ fn load_chacha_rng_setup() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn rng_reflection() {
     use bevy::reflect::{
-        serde::{ReflectSerializer, UntypedReflectDeserializer},
+        serde::{ReflectDeserializer, ReflectSerializer},
         TypeRegistry,
     };
     use ron::ser::to_string;
@@ -305,7 +305,7 @@ fn rng_reflection() {
 
     let mut deserializer = ron::Deserializer::from_str(&serialized).unwrap();
 
-    let de = UntypedReflectDeserializer::new(&registry);
+    let de = ReflectDeserializer::new(&registry);
 
     let value = de.deserialize(&mut deserializer).unwrap();
 

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -236,16 +236,16 @@ fn deterministic_secure_setup() {
     app.update();
 
     let mut q_player = app
-        .world()
+        .world_mut()
         .query_filtered::<&mut ChaChaRngComponent, With<Player>>();
-    let mut player = q_player.single_mut(&mut app.world());
+    let mut player = q_player.single_mut(app.world_mut());
 
     assert_eq!(player.u32(..=10), 0);
 
     let mut q_enemies = app
-        .world()
+        .world_mut()
         .query_filtered::<&mut ChaChaRngComponent, With<Enemy>>();
-    let mut enemies = q_enemies.iter_mut(&mut app.world());
+    let mut enemies = q_enemies.iter_mut(app.world_mut());
 
     let mut enemy_1 = enemies.next().unwrap();
 
@@ -323,7 +323,7 @@ fn rng_reflection() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn chacha_rng_reflection() {
     use bevy::reflect::{
-        serde::{ReflectSerializer, UntypedReflectDeserializer},
+        serde::{ReflectDeserializer, ReflectSerializer},
         TypeRegistry,
     };
     use serde::de::DeserializeSeed;
@@ -353,7 +353,7 @@ fn chacha_rng_reflection() {
 
     let mut deserializer = ron::Deserializer::from_str(&serialized).unwrap();
 
-    let de = UntypedReflectDeserializer::new(&registry);
+    let de = ReflectDeserializer::new(&registry);
 
     let value = de.deserialize(&mut deserializer).unwrap();
 

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -105,7 +105,7 @@ fn deterministic_play_through() {
     // Set up the game App and World
     let mut app = App::new();
 
-    let world = &mut app.world;
+    let world = app.world_mut();
 
     // Initialise our global Rng resource
     let mut global_rng = GlobalRng::with_seed(12345);
@@ -170,25 +170,25 @@ fn deterministic_play_through() {
     app.update();
 
     // Check to see the health of our combatants
-    assert_eq!(app.world.get::<HitPoints>(player).unwrap().total, 100);
-    assert_eq!(app.world.get::<HitPoints>(enemy_1).unwrap().total, 20);
-    assert_eq!(app.world.get::<HitPoints>(enemy_2).unwrap().total, 11);
+    assert_eq!(app.world().get::<HitPoints>(player).unwrap().total, 100);
+    assert_eq!(app.world().get::<HitPoints>(enemy_1).unwrap().total, 20);
+    assert_eq!(app.world().get::<HitPoints>(enemy_2).unwrap().total, 11);
 
     // Again!
     app.update();
 
     // Player OP. Enemy 2 is in trouble
-    assert_eq!(app.world.get::<HitPoints>(player).unwrap().total, 90);
-    assert_eq!(app.world.get::<HitPoints>(enemy_1).unwrap().total, 20);
-    assert_eq!(app.world.get::<HitPoints>(enemy_2).unwrap().total, 3);
+    assert_eq!(app.world().get::<HitPoints>(player).unwrap().total, 90);
+    assert_eq!(app.world().get::<HitPoints>(enemy_1).unwrap().total, 20);
+    assert_eq!(app.world().get::<HitPoints>(enemy_2).unwrap().total, 3);
 
     // And again!
     app.update();
 
     // Enemy 2 is now deceased
-    assert_eq!(app.world.get::<HitPoints>(player).unwrap().total, 88);
-    assert_eq!(app.world.get::<HitPoints>(enemy_1).unwrap().total, 20);
-    assert_eq!(app.world.get::<HitPoints>(enemy_2).unwrap().total, 0);
+    assert_eq!(app.world().get::<HitPoints>(player).unwrap().total, 88);
+    assert_eq!(app.world().get::<HitPoints>(enemy_1).unwrap().total, 20);
+    assert_eq!(app.world().get::<HitPoints>(enemy_2).unwrap().total, 0);
 }
 
 #[test]
@@ -203,14 +203,16 @@ fn deterministic_setup() {
     app.update();
 
     let mut q_player = app
-        .world
+        .world_mut()
         .query_filtered::<&mut RngComponent, With<Player>>();
-    let mut player = q_player.single_mut(&mut app.world);
+    let mut player = q_player.single_mut(app.world_mut());
 
     assert_eq!(player.u32(..=10), 10);
 
-    let mut q_enemies = app.world.query_filtered::<&mut RngComponent, With<Enemy>>();
-    let mut enemies = q_enemies.iter_mut(&mut app.world);
+    let mut q_enemies = app
+        .world_mut()
+        .query_filtered::<&mut RngComponent, With<Enemy>>();
+    let mut enemies = q_enemies.iter_mut(app.world_mut());
 
     let mut enemy_1 = enemies.next().unwrap();
 
@@ -234,16 +236,16 @@ fn deterministic_secure_setup() {
     app.update();
 
     let mut q_player = app
-        .world
+        .world()
         .query_filtered::<&mut ChaChaRngComponent, With<Player>>();
-    let mut player = q_player.single_mut(&mut app.world);
+    let mut player = q_player.single_mut(&mut app.world());
 
     assert_eq!(player.u32(..=10), 0);
 
     let mut q_enemies = app
-        .world
+        .world()
         .query_filtered::<&mut ChaChaRngComponent, With<Enemy>>();
-    let mut enemies = q_enemies.iter_mut(&mut app.world);
+    let mut enemies = q_enemies.iter_mut(&mut app.world());
 
     let mut enemy_1 = enemies.next().unwrap();
 


### PR DESCRIPTION
# Objective

- Prepare `bevy_turborand` to support Bevy 0.14 via the current release candidate (`0.14.0-rc.4`).
- Allow `bevy_turborand` users to try out Bevy 0.14 before the full release

# Solution

- Bump Bevy to `0.14.0-rc.4`
- Fix tests to run on the new Bevy version

I propose to release this change as `0.9.0-rc.1` to enable users of `bevy_turborand` to test Bevy 0.14.
If you don't want that, I can remove the changes to Cargo.toml and the README and we can wait for 0.14 to be fully released.

# Testing

I ran `cargo check` and `cargo test` and it seems to work.
Didn't test this with a real Bevy app yet.